### PR TITLE
Add missing ETag quotes

### DIFF
--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -37,7 +37,7 @@ module.exports = function ({
       })
       .promise()
       .then(data => {
-        if (data.ETag !== lockMD5) {
+        if (data.ETag !== `"${lockMD5}"`) {
           return wait(acquireLockRetryTimeout).then(() => S3.acquireLock())
         }
         return data
@@ -136,7 +136,7 @@ module.exports = function ({
         })
         .promise()
         .then(data => {
-          if (data.ETag !== bodyMD5) {
+          if (data.ETag !== `"${bodyMD5}"`) {
             throw new S3LiteError('ETag different from ContentMD5')
           }
           lockFile.saveTime('pushDatabase', startTime)


### PR DESCRIPTION
The S3 API uses double-quoted eTags which turn out to be spec compliant. Not sure how this ever worked. This fixes them.